### PR TITLE
feat/pm2: kill process before startup by systemd

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,3 +23,5 @@ pm2_version:
 pm2_user: root
 # user home
 pm2_user_home: /root
+# control to start only with systemd
+pm2_app_start: false

--- a/tasks/manage.yml
+++ b/tasks/manage.yml
@@ -13,3 +13,4 @@
     chdir: "{{ item.path | default(omit) }}"
   with_items: "{{ pm2_apps }}"
   become_user: "{{ pm2_user }}"
+  when: pm2_app_start == 'true'

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -1,7 +1,4 @@
 ---
-- name: Kill pm2 before start by systemd
-  command:
-     pkill PM2
 
 - name: Configuring service
   service:

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -1,4 +1,7 @@
 ---
+- name: Kill pm2 before start by systemd
+  command:
+     pkill PM2
 
 - name: Configuring service
   service:


### PR DESCRIPTION
the role start pm2 and when the system will start, they can find the pid file created by app. so the solution was kill the process and let the systemd start again.

```
TASK [pm2 : Configuring service] ***********************************************************************************************************************************************************************************************************************************************
fatal: [ip-172-29-10-250.ec2.internal]: FAILED! => {"changed": false, "failed": true, "msg": "Unable to start service pm2-chubaca: Job for pm2-chubaca.service failed because a configured resource limit was exceeded. See \"systemctl status pm2-chubaca.service\" and \"journalctl -xe\" for details.\n"}
```